### PR TITLE
License file for MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Jean-Tiare Le Bigot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
I'm interested to use (and eventually build on) your packet tracing tool. Would it be possible to distribute the license with the source code (as this pull request proposes)?

As a side effect, this pull request should [help GitHub recognize your repository's license](https://github.com/blog/2252-license-now-displayed-on-repository-overview). GitHub uses [Licensee](https://github.com/benbalter/licensee) to detect licenses and, by default, it only works if the license is distributed with the code, [in a separate file](https://github.com/benbalter/licensee/blob/master/docs/what-we-look-at.md#what-about-looking-to-see-if-the-author-said-something-in-the-readme) (their lawyers made the argument that references in READMEs are insufficient).